### PR TITLE
Use Array#sample for better Ruby compatibility

### DIFF
--- a/lib/bandit.rb
+++ b/lib/bandit.rb
@@ -15,6 +15,7 @@ require "bandit/storage/memcache"
 require "bandit/storage/redis"
 
 require "bandit/extensions/controller_concerns"
+require "bandit/extensions/array"
 require "bandit/extensions/view_concerns"
 require "bandit/extensions/time"
 require "bandit/extensions/string"

--- a/lib/bandit/experiment.rb
+++ b/lib/bandit/experiment.rb
@@ -20,8 +20,8 @@ module Bandit
       @@instances
     end
 
-    def choose(default = nil)
-      if not default.nil? and alternatives.include? default
+    def choose(default=nil)
+      if default && alternatives.include?(default)
         alt = default
       else
         alt = Bandit.player.choose_alternative(self)

--- a/lib/bandit/extensions/array.rb
+++ b/lib/bandit/extensions/array.rb
@@ -1,0 +1,3 @@
+class Array
+  alias_method :sample, :choice unless method_defined?(:sample)
+end

--- a/lib/bandit/players/epsilon_greedy.rb
+++ b/lib/bandit/players/epsilon_greedy.rb
@@ -9,7 +9,7 @@ module Bandit
       if rand <= (1-epsilon)
         best_alternative(experiment)
       else
-        experiment.alternatives.choice
+        experiment.alternatives.sample
       end
     end
 

--- a/lib/bandit/players/round_robin.rb
+++ b/lib/bandit/players/round_robin.rb
@@ -1,7 +1,7 @@
 module Bandit
   class RoundRobinPlayer < BasePlayer
     def choose_alternative(experiment)
-      experiment.alternatives.choice
+      experiment.alternatives.sample
     end
   end
 end


### PR DESCRIPTION
`Array#choice` is only defined in Ruby 1.8.7. Future versions define `Array#sample`.

In b8348512 I update the `epsilon_greedy` and `round_robin` players to use `Array#sample`, while monkey-patching `Array` to define an alias for `sample` to `choice` to maintain compatibility in Ruby 1.8.7.

Ran tests against Ruby 1.8.7 and 1.9.3, but I'm not sure the current tests actually cover that particular code path.

Also, thanks for writing this before I got a chance. You have saved me some time ;)
