### PR TITLE
Adding Dalli Storage support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,7 +12,7 @@ Then, run the following:
     bundle install
     rails generate bandit:install
 
-You can then edit the bandit.yml file in your config directory to set your storage and player parameters.  Redis, memcache, and memory storage options are available.  Memory storage should only be used for testing.
+You can then edit the bandit.yml file in your config directory to set your storage and player parameters.  Redis, memcache, dalli (memcache client alternative) and memory storage options are available.  Memory storage should only be used for testing.
 
 See the file players.rdoc for information about available players.
 

--- a/lib/bandit.rb
+++ b/lib/bandit.rb
@@ -13,6 +13,7 @@ require "bandit/storage/base"
 require "bandit/storage/memory"
 require "bandit/storage/memcache"
 require "bandit/storage/redis"
+require "bandit/storage/dalli"
 
 require "bandit/extensions/controller_concerns"
 require "bandit/extensions/array"
@@ -32,7 +33,7 @@ module Bandit
     config.check!
     # intern keys in storage config
     config.storage_config = config.storage_config.inject({}) { |n,o| n[o.first.intern] = o.last; n }
-  end  
+  end
 
   def self.storage
     # try using configured storage at least once every 5 minutes until resolved
@@ -53,7 +54,7 @@ module Bandit
   end
 
   def self.get_experiment(name)
-    exp = Experiment.instances.select { |e| e.name == name } 
+    exp = Experiment.instances.select { |e| e.name == name }
     exp.length > 0 ? exp.first : nil
   end
 

--- a/lib/bandit/storage/base.rb
+++ b/lib/bandit/storage/base.rb
@@ -17,9 +17,10 @@ module Bandit
     def self.get_storage(name, config)
       config ||= {}
 
-      case name 
+      case name
       when :memory then MemoryStorage.new(config)
       when :memcache then MemCacheStorage.new(config)
+      when :dalli then DalliStorage.new(config)
       when :redis then RedisStorage.new(config)
       else raise UnknownStorageEngineError, "#{name} not a known storage method"
       end
@@ -50,17 +51,17 @@ module Bandit
       raise NotImplementedError
     end
 
-    def incr_participants(experiment, alternative, count=1, date_hour=nil)      
+    def incr_participants(experiment, alternative, count=1, date_hour=nil)
       date_hour ||= DateHour.now
 
       # initialize first start time for alternative if we haven't inited yet
       init alt_started_key(experiment, alternative), date_hour.to_i
-      
+
       # increment total count and per hour count
       incr part_key(experiment, alternative), count
       incr part_key(experiment, alternative, date_hour), count
     end
-    
+
     def incr_conversions(experiment, alternative, count=1, date_hour=nil)
       # increment total count and per hour count
       incr conv_key(experiment, alternative), count
@@ -78,7 +79,7 @@ module Bandit
     def conversion_count(experiment, alternative, date_hour=nil)
       get conv_key(experiment, alternative, date_hour)
     end
-    
+
     def player_state_set(experiment, player, name, value)
       set player_state_key(experiment, player, name), value
     end
@@ -91,7 +92,7 @@ module Bandit
       secs = get alt_started_key(experiment, alternative), nil
       secs.nil? ? nil : Time.at(secs).to_date_hour
     end
-    
+
     # if date_hour is nil, create key for total
     # otherwise, create key for hourly based
     def part_key(exp, alt, date_hour=nil)

--- a/lib/bandit/storage/dalli.rb
+++ b/lib/bandit/storage/dalli.rb
@@ -1,0 +1,44 @@
+module Bandit
+  class DalliStorage < BaseStorage
+    def initialize(config)
+      require 'dalli'
+      config[:namespace] ||= 'bandit'
+      @dalli = Dalli::Client.new(config.fetch(:host, 'localhost:11211'), config)
+    end
+
+    # increment key by count
+    def incr(key, count=1)
+      # memcache incr seems to be broken in memcache-client gem
+      with_failure_grace(count) {
+        @dalli.incr(key, count)
+      }
+    end
+
+    # initialize key if not set
+    def init(key, value)
+      with_failure_grace(value) {
+        @dalli.add(key, value)
+      }
+    end
+
+    # get key if exists, otherwise 0
+    def get(key, default=0)
+      with_failure_grace(default) {
+        @dalli.get(key) || default
+      }
+    end
+
+    # set key with value, regardless of whether it is set or not
+    def set(key, value)
+      with_failure_grace(value) {
+        @dalli.set(key, value)
+      }
+    end
+
+    def clear!
+      with_failure_grace(nil) {
+        @dalli.flush_all
+      }
+    end
+  end
+end


### PR DESCRIPTION
Hi @bmuller, 

Here goes my first contribution to add support to [Dalli](https://github.com/mperham/dalli) as an alternative to memcache-client that I saw you were using. 

This seems to work showing alternatives, but I'm not quite sure if it's tracking conversions. I see the keys in the memcached server, but tracks are not shown in bandit dashboad. I don't know how to assure the thing is working. Any idea?

Regards!
