### PR TITLE
Adding Softmax Player

### DIFF
--- a/lib/bandit.rb
+++ b/lib/bandit.rb
@@ -8,6 +8,7 @@ require "bandit/memoizable"
 require "bandit/players/base"
 require "bandit/players/round_robin"
 require "bandit/players/epsilon_greedy"
+require "bandit/players/softmax"
 
 require "bandit/storage/base"
 require "bandit/storage/memory"

--- a/lib/bandit/players/base.rb
+++ b/lib/bandit/players/base.rb
@@ -6,6 +6,7 @@ module Bandit
       case name 
       when :round_robin then RoundRobinPlayer.new(config)
       when :epsilon_greedy then EpsilonGreedyPlayer.new(config)
+      when :softmax then SoftmaxPlayer.new(config)
       else raise UnknownPlayerEngineError, "#{name} not a known player type"
       end
     end

--- a/lib/bandit/players/softmax.rb
+++ b/lib/bandit/players/softmax.rb
@@ -1,0 +1,36 @@
+module Bandit
+  class SoftmaxPlayer < BasePlayer
+    include Memoizable
+
+    def choose_alternative(experiment)
+      memoize(experiment.name) {
+        t = getTemperature(experiment)
+        norms = experiment.alternatives.map { |alt| 
+          Math.exp(experiment.conversion_rate(alt) / (t * 100))
+        }
+        scale = norms.reduce(:+)
+        probs = norms.map { |n| n / scale }
+        a = alternative_index(probs)
+        experiment.alternatives[alternative_index(probs)]
+      }
+    end
+
+    private
+
+    def alternative_index(probs)
+      p = rand
+      prob_sum = 0.0
+
+      probs.size.times { |i|
+        prob_sum += probs[i]
+        return i if prob_sum > p
+      }
+
+      return probs.size - 1
+    end
+
+    def getTemperature(experiment)
+      @config['temperature'].to_f || 0.2
+    end
+  end
+end

--- a/players.rdoc
+++ b/players.rdoc
@@ -11,6 +11,15 @@ The epsilon greedy player selects the best alternative with a probability of 1 -
         epsilon: 0.1
       ...
 
+== Softmax
+The softmax player selects an an alternative with a probability based on its past success compared to the other alternatives.  The temperature determines how likely the player is to explore less successful alternatives.
+
+    production:
+      ...
+      player: softmax
+      player_config:
+        temperature: 0.2
+      ...
 
 == Round Robin
 This is included for testing purposes only.  It will not optimize.  There are no config options.


### PR DESCRIPTION
The softmax algorithm is an alternative to the epsilon-greedy algorithm.
Instead of picking based on a set probability, it uses a 'temperature'
parameter, along with the known data to set the distribution of the
alternatives.

lib/bandit.rb requires the softmax player
lib/bandit/players/base.rb adds a softmax option to the factory
lib/bandit/players/softmax.rb implements the player
players.rdoc provides a short explanation
