### PR TITLE
Adding Rake test_player task

### DIFF
--- a/lib/generators/bandit/templates/bandit.rake
+++ b/lib/generators/bandit/templates/bandit.rake
@@ -17,4 +17,42 @@ namespace :bandit do
     }
   end
 
+  desc 'test the configured player'
+  task :test_player, [:experiment, :force] => [:environment] do |t, args|
+    storage = Bandit.storage
+    exp = Bandit.get_experiment args[:experiment].intern
+    raise "No such experiment defined: #{args[:experiment]}" if exp.nil?
+
+    force = !!args[:force]
+    if !(Rails.env.development? || Rails.env.test?) && !force
+      raise "Be careful! Environment is #{Rails.env}. " 
+            "Call with force=true to continue"
+    end
+
+    class << Bandit.player
+      def memoize(key, time=0)
+        yield
+      end
+    end
+
+    rates = {}
+    exp.alternatives.each { |alt, i|
+      rates[alt] = rand
+    }
+
+    storage.clear!
+    1000.times { |_|
+      alt = exp.choose
+      exp.convert!(alt) if rand < rates[alt]
+    }
+
+    printf "%10s%10s%10s%10s\n", *%w(alts visits convert rate)
+    exp.alternatives.each { |alt|
+      v = exp.participant_count(alt)
+      c = exp.conversion_rate(alt)
+      r = rates[alt]
+
+      printf "%10.4f%10d%10.4f%10.4f\n", alt, v, c, r
+    }
+  end
 end


### PR DESCRIPTION
Usage: rake bandit:test_player[&lt;test_name&gt;{,&lt;true|false&gt;}]

The test_player task is called with one mandatory argument, the name of
an experiment, and one optional parameter, a boolean determing whether
or not to force.  The configured player for the given environment is the
player that is tested.

Force is only required if running the test in a non-development,
non-test environment.

The purpose of the task to to check if conversion_rates line up nicely
with the player's options.  It can be used to check the accuracy of
players, or to learn what kind of results they produce.
