### PR TITLE
Adhering to Rails 3.1+ asset pipeline structure

### DIFF
--- a/lib/generators/bandit/dashboard_generator.rb
+++ b/lib/generators/bandit/dashboard_generator.rb
@@ -16,8 +16,8 @@ module Bandit
       end
 
       def copy_assets
-        directory 'dashboard/js', 'vendor/javascripts/bandit'
-        directory 'dashboard/css', 'vendor/stylesheets/bandit'
+        directory 'dashboard/js', 'vendor/assets/javascripts/bandit'
+        directory 'dashboard/css', 'vendor/assets/stylesheets/bandit'
       end
 
       def message


### PR DESCRIPTION
According to the [asset pipeline rails guide](http://guides.rubyonrails.org/asset_pipeline.html#asset-organization),
vendor javascripts and stylesheets belong in vendor/assets/javascripts
and vendor/assets/stylesheets.  This lets the asset pipeline include the
files by default.
