### PR TITLE
Allow connection to Redis instance via URL

### DIFF
--- a/lib/bandit/storage/redis.rb
+++ b/lib/bandit/storage/redis.rb
@@ -2,9 +2,18 @@ module Bandit
   class RedisStorage < BaseStorage
     def initialize(config)
       require 'redis'
-      config[:host] ||= 'localhost'
-      config[:port] ||= 6379
+
+      if config[:url]
+        uri = URI.parse(config[:url])
+        config[:host] = uri.host
+        config[:port] = uri.port
+        config[:password] = uri.password
+      else
+        config[:host] ||= 'localhost'
+        config[:port] ||= 6379
+      end
       config[:db] ||= "bandit"
+
       @redis = Redis.new config
     end
 

--- a/lib/generators/bandit/templates/bandit.yml
+++ b/lib/generators/bandit/templates/bandit.yml
@@ -14,3 +14,12 @@ production:
   storage_config:
     host: localhost
     port: 6379
+
+# To use a Redis instance via URL (e.g. RedisToGo)
+# production: 
+#   player: epsilon_greedy
+#   player_config:
+#     epsilon: 0.1
+#   storage: redis
+#   storage_config:
+#     url: redis://redistogo:abcdef012345@somewhere.redistogo.com:10020


### PR DESCRIPTION
I'm using Bandit on Heroku with a Redis DB provided by RedisToGo. The connection details are available via a URL formatted like this:

`redis://redistogo:abcdef012345@somewhere.redistogo.com:10020`

This pull requests lets you connect to a Redis instance via a URL rather than simply host and port.
