### PR TITLE
Adding cascading options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source "http://rubygems.org"
 
+group :test do
+  gem 'mocha', '0.13.2'
+end
+
 # Specify your gem's dependencies in bandit.gemspec
 gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -25,7 +25,12 @@ To set up an experiment, add it either somewhere in your code or in the bandit i
       exp.alternatives = [ 20, 30, 40 ]
       exp.title = "Click Test"
       exp.description = "A test of clicks on purchase page with varying link sizes."
+
+      #A custom configuration option for this experiment
+      exp.options[:epsilon] = 0.7
     }
+
+Player config (player_config) values are chosen in a cascading manner. Experiment options take precedence over config options, which take precedence over default values.  Options can be assigned in multiple places, with the item of highest precedence being chosen on a per-experiment basis.  Experiment options (exp.options) only overwrite player_config values and therefore only apply to players.
 
 
 == View

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,13 @@ Rake::RDocTask.new("doc") { |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 }
 
+desc "Run all unit tests"
+Rake::TestTask.new("test_all") { |t|
+  t.libs << "lib"
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
+}
+
 desc "Run all unit tests with memory storage"
 Rake::TestTask.new("test_memory") { |t|
   t.libs << "lib"
@@ -39,5 +46,12 @@ desc "Run all unit tests with redis storage"
 Rake::TestTask.new("test_redis") { |t|
   t.libs << "lib"
   t.test_files = FileList['test/redis_*.rb']
+  t.verbose = true
+}
+
+desc "Run unit test for cascading options"
+Rake::TestTask.new("test_cascading_options") { |t|
+  t.libs << "lib"
+  t.test_files = FileList['test/cascading_options_test.rb']
   t.verbose = true
 }

--- a/lib/bandit/experiment.rb
+++ b/lib/bandit/experiment.rb
@@ -1,6 +1,8 @@
 module Bandit
   class Experiment
     attr_accessor :name, :title, :description, :alternatives
+    attr_reader :options
+
     @@instances = []
 
     def self.create(name)
@@ -14,6 +16,7 @@ module Bandit
       args.each { |k,v| send "#{k}=", v } unless args.nil?
       @@instances << self
       @storage = Bandit.storage
+      @options = {}
     end
 
     def self.instances

--- a/lib/bandit/players/base.rb
+++ b/lib/bandit/players/base.rb
@@ -35,5 +35,13 @@ module Bandit
     def name
       self.class.to_s
     end
+
+    private 
+
+    def get_option(exp, name, default)
+      return exp.options[name] unless exp.options[name].nil?
+      return @config[name] unless @config[name].nil?
+      return default
+    end
   end
 end

--- a/lib/bandit/players/epsilon_greedy.rb
+++ b/lib/bandit/players/epsilon_greedy.rb
@@ -3,7 +3,7 @@ module Bandit
     include Memoizable
 
     def choose_alternative(experiment)
-      epsilon = @config['epsilon'].to_f || 0.1
+      epsilon = get_option(experiment, :epsilon, 0.1).to_f
 
       # choose best with probability of 1-epsilon
       if rand <= (1-epsilon)

--- a/lib/bandit/players/softmax.rb
+++ b/lib/bandit/players/softmax.rb
@@ -4,7 +4,7 @@ module Bandit
 
     def choose_alternative(experiment)
       memoize(experiment.name) {
-        t = getTemperature(experiment)
+        t = get_option(experiment, :temperature, 0.2).to_f
         norms = experiment.alternatives.map { |alt| 
           Math.exp(experiment.conversion_rate(alt) / (t * 100))
         }
@@ -27,10 +27,6 @@ module Bandit
       }
 
       return probs.size - 1
-    end
-
-    def getTemperature(experiment)
-      @config['temperature'].to_f || 0.2
     end
   end
 end

--- a/lib/generators/bandit/templates/bandit.rb
+++ b/lib/generators/bandit/templates/bandit.rb
@@ -1,6 +1,7 @@
 # Use this setup block to configure all options for Bandit.
 Bandit.setup do |config|
   yml = YAML.load_file("#{Rails.root}/config/bandit.yml")[Rails.env]
+  yml = HashWithIndifferentAccess.new(yml)
 
   config.player = yml['player']
   config.player_config = yml['player_config']

--- a/test/cascading_options_test.rb
+++ b/test/cascading_options_test.rb
@@ -1,0 +1,39 @@
+require File.join File.dirname(__FILE__), 'helper'
+
+class CascadingOptionsTest < Test::Unit::TestCase
+  include SetupHelper
+
+  def setup
+    @default = 1
+
+    config = Bandit.config
+    config.storage = "memory"
+    config.player_config = { option: 2 }
+    @player_config = config.player_config
+
+    @player = Bandit::BasePlayer.get_player(:round_robin, @player_config)
+
+    options = { option: 3 }
+    @exp = mock('experiment')
+    @exp.stubs(:options).returns(options)
+  end
+
+  def get_option
+    @player.send(:get_option, @exp, :option, @default).to_i
+  end
+
+  def test_default_option
+    @player_config[:option] = nil
+    @exp.options[:option] = nil
+    assert_equal(get_option, @default)
+  end
+
+  def test_config_option
+    @exp.options[:option] = nil
+    assert_equal(get_option, @player_config[:option])
+  end
+
+  def test_experiment_option
+    assert_equal(get_option, @exp.options[:option])
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'test/unit'
+require 'mocha/setup'
 require 'yaml'
 
 $:.unshift(File.join File.dirname(__FILE__), '..', 'lib')


### PR DESCRIPTION
This feature adds cascading options (similar to how css cascades) for
player_config options.  This is desirable for situations where users would 
want different configuration options for different experiments.  The changes 
are listed under Configuration in README.rdoc.

Changed files:

Gemfile: adds mocha for mocking in unit tests (not needed for deployment)

Rakefile: adds test_cascading_options and test_all tasks

experiment.rb: adds a readable options hash (to be edited, but not set)

epsilon_greedy.rb: takes advantage of BasePlayer#get_option for :epsilon

softmax.rb: takes advantage of BasePlayer#get_option for :temperature

generators/bandit/templates/bandit.rb: makes the yml hash a
HashWithIndifferentAccess so it can be accessed with strings or symbols

test/cascading_options_test.rb: unit tests for cascading options

test/helper.rb: including mocha
