### PR TITLE
Make Dalli::Client server more flexible

### DIFF
--- a/lib/bandit/storage/dalli.rb
+++ b/lib/bandit/storage/dalli.rb
@@ -3,7 +3,8 @@ module Bandit
     def initialize(config)
       require 'dalli'
       config[:namespace] ||= 'bandit'
-      @dalli = Dalli::Client.new(config.fetch(:host, 'localhost:11211'), config)
+      server = "#{config[:host]}:#{config.fetch([:port], 11211)}" if config[:host]
+      @dalli = Dalli::Client.new(server, config)
     end
 
     # increment key by count


### PR DESCRIPTION
Before it was only possible to use the host specified in `bandit.yml` (and the port was ignored as well). Now, if the host isn't specified in the config Dalli will properly fall back to using `ENV["MEMCACHE_SERVERS"]` or `127.0.0.1:11211`.

See: https://github.com/mperham/dalli/blob/master/lib/dalli/client.rb#L29

This makes it easier to get it running on platforms like Heroku.
