### PR TITLE
Require Rails 3.1+, not 3.2+

### DIFF
--- a/bandit.gemspec
+++ b/bandit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency("rails", ">= 3.2.0")
+  s.add_dependency("rails", ">= 3.1.0")
   s.requirements << "Either redis or memcache gem"
   s.add_development_dependency('rdoc')
 end


### PR DESCRIPTION
A recent change made bandit dependent on Rails 3.2+. I don't think this was necessary. I believe that bandit still works with Rails 3.1, and I have some 3.1 apps I'd like to use with bandit. 
